### PR TITLE
Update MLOps sections to operate standalone

### DIFF
--- a/sections/ai-workflows-and-mlops.qmd
+++ b/sections/ai-workflows-and-mlops.qmd
@@ -67,17 +67,17 @@ MLOps addresses these pain points by providing:
 
 MLOps isn't just another buzzword—it's a crucial evolution in how we develop and deploy ML systems. As models become more complex and requirements for reliability increase, MLOps practices become essential for successful ML implementations.
 
-## MLflow: A Comprehensive Platform for the ML Lifecycle 
+## MLflow: A Comprehensive Platform for the ML Lifecycle
 
 ### What is MLflow? {.unnumbered}
 
 MLflow is an open-source platform designed to manage the end-to-end machine learning lifecycle. Created by Databricks, it provides a unified set of tools that address the core challenges in developing, training, and deploying machine learning models. MLflow is language-agnostic and can work with any ML library, algorithm, or deployment tool.
 
-### The PDG MLFlow Tracking Server {.unnumbered}
-The Permafrost Discovery Gateway project has a shared MLFlow instance
-that you can use for your arctic research:
-
-[https://pdg.mflow.software.ncsa.illinois.edu](https://pdg.mflow.software.ncsa.illinois.edu)
+### The MLFlow Tracking Server {.unnumbered}
+There are two components to MLFlow, the Python, R, and Java libraries that allow you to
+instrument your training code and a tracking server that records training runs and hosts the
+model repository. For serious production use, you will need a hosted tracking server.
+Fortunately, for tutorials and personal use, you can run a local tracking server.
 
 ### Key Components of MLflow {.unnumbered}
 MLFlow consists of three main components:
@@ -205,6 +205,20 @@ mlflow run --backend slurm \
 
 
 ## Hands-On Tutorial
+For this tutorial you will need a local JupyterLab running from a conda environment as outlined in Section 0.
+
+You will also  need a local MLFlow tracking server.
+
+To install and run an MLFlow tracking server locally, you first need to install MLFlow via pip with:
+```
+pip install mlflow
+```
+Once installed, you can start a basic tracking server by running the command
+```
+mlflow server --backend-store-uri sqlite:///mlflow.db
+```
+This sets up a server using SQLite for storage, creates a local directory for artifacts, binds to all network interfaces, and runs on port 5000. You can then access the MLFlow UI by navigating to http://localhost:5000 in your web browser, where you can view, compare, and manage your machine learning experiments.
+
 We will be using a GPU powered JuypterHub provided by NCSA. Connection
 instructions will be provided in the classroom.
 

--- a/sections/hands-on-lab-ai-workflows.qmd
+++ b/sections/hands-on-lab-ai-workflows.qmd
@@ -45,13 +45,13 @@ In order for your model to be published to garden, it must be:
 All of the examples in this lab are available in the workshop repository. Clone the
 repository to your local machine:
 ```
-git clone https://github.com/Garden-AI/uploadathon.git
+git clone https://github.com/cyber2a/ml-workflows.git
 ```
 
 In this step we will upload an existing trivial model to garden and execute it
 from a Google Colab notebook.
 
-Use the [hello_garden.py](https://github.com/Garden-AI/uploadathon/blob/main/hello_world.py)
+Use the [hello_garden.py](https://github.com/cyber2a/ml-workflows/blob/main/hello_world.py)
 from the example repo and upload it from the garden form.
 
 Keep it a “test garden” and don’t worry too hard about the metadata
@@ -61,6 +61,10 @@ Once you’ve created it, go make sure you can invoke it remotely. Try out this
 to see it in action.
 
 ## Step 2: Learn how to iterate on Modal apps {.unnumbered}
+Garden uses the [modal service](https://modal.com/docs/guide) to host models
+and make it easy to perform inference from a noteook. This is a commercial service, but
+the free tier is entirely sufficient for most purposes and won't require a credit card.
+
 In this step we will learn more about creating and debugging a modal app.
 
 Install the modal package:
@@ -68,7 +72,7 @@ Install the modal package:
 pip install modal
 ```
 
-Download [needs_a_tweak.py](https://github.com/Garden-AI/uploadathon/blob/main/needs_a_tweak.py) and try
+Download [needs_a_tweak.py](https://github.com/cyber2a/ml-workflows/blob/main/needs_a_tweak.py) and try
 running it with
 ```
 modal run needs_a_tweak.py
@@ -83,11 +87,11 @@ every time they run.
 Your model weights will need to live somewhere publicly accessible.
 Garden can’t pull them from your machine.
 
-- See [git_model_staging.py](https://github.com/Garden-AI/uploadathon/blob/main/git_model_staging.py) for an example of how to use weights hosted in GitHub or Hugging Face.
-- See [figshare_model_staging.py](https://github.com/Garden-AI/uploadathon/blob/main/figshare_model_staging.py) for an example of how to pull weights from a FigShare download link.
+- See [git_model_staging.py](https://github.com/cyber2a/ml-workflows/blob/main/git_model_staging.py) for an example of how to use weights hosted in GitHub or Hugging Face.
+- See [figshare_model_staging.py](https://github.com/cyber2a/ml-workflows/blob/main/figshare_model_staging.py) for an example of how to pull weights from a FigShare download link.
 
 ## Step 4: Run a "Real Model" {.unnumbered}
-Take a look at the [Retrograde Thaw Slump model](https://github.com/Garden-AI/uploadathon/blob/main/examples/ESIP/RTS/rts.py).
+Take a look at the [Retrogressive Thaw Slump model](https://github.com/cyber2a/ml-workflows/blob/main/examples/ESIP/RTS/rts.py).
 You can execute the model from the [google colab notebook](https://colab.research.google.com/drive/1slJ0h_nK1UEFKrDUE0YDz53EqWyt7kg4) to see it in action.
 
 ## Next Steps {.unnumbered}


### PR DESCRIPTION
As part of the course review, we've decided that the hands-on portion of the course should not rely on NCSA hosted software.

Update the tutorial for running jupyterlab and MLFlow locally.

Also migrate the garden tutorial to the cyber2a organization